### PR TITLE
Added Nuke Tools deployment to workstations

### DIFF
--- a/.github/scripts/update-ssm-parameter.sh
+++ b/.github/scripts/update-ssm-parameter.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+# Script to update a key-value pair in an AWS SSM Parameter Store
+# Usage: update-ssm-parameter.sh <parameter-name> <key> <value> <region>
+
+if [ $# -ne 4 ]; then
+    echo "Usage: $0 <parameter-name> <key> <value> <region>"
+    echo "Example: $0 /workstations/2025.0.0 NUKE_TOOLS v1.2.3 eu-west-1"
+    exit 1
+fi
+
+PARAMETER_NAME="$1"
+KEY="$2"
+VALUE="$3"
+REGION="$4"
+
+echo "Downloading parameter store: ${PARAMETER_NAME}"
+# Download the current parameter store value
+CONFIG=$(aws ssm get-parameter \
+    --name "${PARAMETER_NAME}" \
+    --region "${REGION}" \
+    --query "Parameter.Value" \
+    --output text)
+
+echo "Updating ${KEY} to ${VALUE}"
+# Update the key value with the new value
+# If key exists, update it; otherwise append it
+if echo "$CONFIG" | grep -q "^${KEY}="; then
+    UPDATED_VALUE=$(echo "$CONFIG" | sed "s/^${KEY}=.*/${KEY}=${VALUE}/")
+else
+    UPDATED_VALUE="${CONFIG}"$'\n'"${KEY}=${VALUE}"
+fi
+
+echo "Uploading updated parameter store"
+# Upload the updated parameter store back
+aws ssm put-parameter \
+    --name "${PARAMETER_NAME}" \
+    --value "$UPDATED_VALUE" \
+    --type "String" \
+    --overwrite \
+    --region "${REGION}"
+
+echo "Successfully updated ${KEY} in ${PARAMETER_NAME}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: Deploy Nuke Tools on Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to deploy (e.g., 1.0.6)'
+        required: true
+        default: '1.0.6'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: eu-west-1
+      SSM_PARAMETER_NAME: /workstations/2025.0.0
+      SSM_PARAMETER_ARN: arn:aws:ssm:eu-west-1:597088022503:parameter/workstations/2025.0.0
+      SSM_PARAMETER_KEY: NUKE_TOOLS
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+            ref: ${{ env.RELEASE_TAG }}
+
+        - name: Setup OIDC
+          shell: bash
+          run: |
+            echo "OIDC_ROLE=$(make -s -f $GITHUB_WORKSPACE/Makefile get-oidc-role PROJECT_ENV=prod-shared-services)" >> $GITHUB_ENV
+            echo "OIDC_SESSION=$(make -s -f $GITHUB_WORKSPACE/Makefile get-oidc-session PROJECT_ENV=prod-shared-services)" >> $GITHUB_ENV
+
+        - name: Configure AWS Credentials
+          uses: aws-actions/configure-aws-credentials@v2
+          with:
+            aws-region: ${{ env.AWS_REGION }}
+            role-to-assume: ${{ env.OIDC_ROLE }}
+            role-session-name: ${{ env.OIDC_SESSION }}
+
+        - name: Update NUKE_TOOLS version in SSM Parameter Store
+          run: |
+            .github/scripts/update-ssm-parameter.sh \
+              "${SSM_PARAMETER_NAME}" \
+              "${SSM_PARAMETER_KEY}" \
+              "${RELEASE_TAG}" \
+              "${AWS_REGION}"
+
+        - name: Copy files to S3 with release version
+          run: |
+            aws s3 sync . s3://flwls-shared-services-prod-eu-west-1-workstation-deployments/nuke_tools/${RELEASE_TAG}/ \
+              --exclude ".git/*" \
+              --exclude ".github/*" \
+              --region "${{ env.AWS_REGION }}"

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ ehthumbs.db
 Thumbs.db
 *~
 
-
+.history/*
 
 ##################### Standard GitHub list
 


### PR DESCRIPTION
- Updating  /workstation/2025.0.0 parameter store on new release
- Create reusable bash script (.github/scripts/update-ssm-parameter.sh) to update key-value pairs in SSM
- Add workflow_dispatch trigger for testing (temporary, not for merge to main)